### PR TITLE
Add adavanced option (WIP)

### DIFF
--- a/cli-inputs.js
+++ b/cli-inputs.js
@@ -121,10 +121,78 @@ const inputOutputType = async () => {
   return outputType;
 };
 
+const inputTargetBranch = async () => {
+  const { targetBranch } = await prompts({
+    type: 'text',
+    name: 'targetBranch',
+    message: 'Branch to create pull requests against.',
+    initial: 'master',
+    validate: (value) => (!value ? 'Please enter a branch name.' : true),
+  });
+
+  return targetBranch;
+};
+
+const inputDefaultReviewers = async () => {
+  const { defaultReviewers } = await prompts({
+    type: 'text',
+    name: 'defaultReviewers',
+    message:
+      'Reviewers to set on update pull requests. (If you are using multiple labels, please separate them by commas.)',
+    initial: '',
+    validate: (value) => (!value ? 'Please enter a default reviewers.' : true),
+  });
+
+  return defaultReviewers;
+};
+
+const inputDefaultAssignees = async () => {
+  const { defaultAssignees } = await prompts({
+    type: 'text',
+    name: 'defaultAssignees',
+    message:
+      'Assignees to set on update pull requests. (If you are using multiple labels, please separate them by commas.)',
+    initial: '',
+    validate: (value) => (!value ? 'Please enter a default assignees.' : true),
+  });
+
+  return defaultAssignees;
+};
+
+const inputDefaultLabels = async () => {
+  const { defaultLabels } = await prompts({
+    type: 'text',
+    name: 'defaultLabels',
+    message:
+      'Labels to set on update pull requests. (If you are using multiple labels, please separate them by commas.)',
+    initial: '',
+    validate: (value) => (!value ? 'Please enter a default labels.' : true),
+  });
+
+  return defaultLabels;
+};
+
+const inputDefaultMilestone = async () => {
+  const { defaultMilestone } = await prompts({
+    type: 'text',
+    name: 'defaultMilestone',
+    message: 'Milestone to set on dependency update pull requests.',
+    initial: '',
+    validate: (value) => (!value ? 'Please enter a defaultMilestone.' : true),
+  });
+
+  return defaultMilestone;
+};
+
 module.exports = {
   inputPackageManager,
   inputDirectory,
   inputUpdateSchedule,
   inputUpdateTyep,
   inputOutputType,
+  inputTargetBranch,
+  inputDefaultReviewers,
+  inputDefaultAssignees,
+  inputDefaultLabels,
+  inputDefaultMilestone,
 };

--- a/index.js
+++ b/index.js
@@ -7,9 +7,16 @@ const {
   inputUpdateSchedule,
   inputUpdateTyep,
   inputOutputType,
+  inputTargetBranch,
+  inputDefaultReviewers,
+  inputDefaultAssignees,
+  inputDefaultLabels,
+  inputDefaultMilestone,
 } = require('./cli-inputs');
 
 (async () => {
+  const isAdvancedOption = process.argv[2] === 'advanced';
+
   const packageManager = await inputPackageManager();
 
   const directory = await inputDirectory();
@@ -22,11 +29,35 @@ const {
 
   const isTerminalOutput = outputType === 'terminal';
 
-  generate(
+  let targetBranch;
+  let defaultReviewers;
+  let defaultAssignees;
+  let defaultLabels;
+  let defaultMilestone;
+  if (isAdvancedOption) {
+    targetBranch = await inputTargetBranch();
+    defaultReviewers = await inputDefaultReviewers();
+    defaultAssignees = await inputDefaultAssignees();
+    defaultLabels = await inputDefaultLabels();
+    defaultMilestone = await inputDefaultMilestone();
+
+    // TODO:
+    // const allowedUpdates = await inputAllowedUpdates();
+    // const ignoreUpdates = await inputIgnoreUpdates();
+    // const versionRequirementsUpdates =  await inputVersionRequirementsUpdates();
+    // const commitMessage = await inputCommitMessage();
+  }
+
+  generate({
     packageManager,
     directory,
     updateSchedule,
     updateType,
-    isTerminalOutput
-  );
+    targetBranch,
+    defaultReviewers,
+    defaultAssignees,
+    defaultLabels,
+    defaultMilestone,
+    isTerminalOutput,
+  });
 })();

--- a/yaml.js
+++ b/yaml.js
@@ -21,13 +21,18 @@ const generateConfigFile = async (configObj) => {
   return;
 };
 
-module.exports.generate = async (
-  packageManeger,
+module.exports.generate = async ({
+  packageManager,
   directory,
   updateSchedule,
   updateType,
-  isTerminalOutput
-) => {
+  targetBranch,
+  defaultReviewers,
+  defaultAssignees,
+  defaultLabels,
+  defaultMilestone,
+  isTerminalOutput,
+}) => {
   const version = 1;
 
   const automerged_updates = [
@@ -41,12 +46,32 @@ module.exports.generate = async (
 
   const update_configs = [
     {
-      package_manager: packageManeger,
+      package_manager: packageManager,
       directory,
       update_schedule: updateSchedule,
       automerged_updates,
     },
   ];
+
+  if (targetBranch) {
+    update_configs[0].target_branch = targetBranch;
+  }
+
+  if (defaultReviewers) {
+    update_configs[0].default_reviewers = defaultReviewers.split(',');
+  }
+
+  if (defaultAssignees) {
+    update_configs[0].default_assignees = defaultAssignees.split(',');
+  }
+
+  if (defaultLabels) {
+    update_configs[0].default_labels = defaultLabels.split(',');
+  }
+
+  if (defaultMilestone) {
+    update_configs[0].default_milestone = defaultMilestone;
+  }
 
   const configObj = { version, update_configs };
 


### PR DESCRIPTION
Add adavanced option.

```bash
dependabot-config-generator advanced
```

- [x] target_branch
https://dependabot.com/docs/config-file/#target_branch
- [x] default_reviewers
https://dependabot.com/docs/config-file/#default_reviewers
- [x] default_assignees
https://dependabot.com/docs/config-file/#default_assignees
- [x] default_labels
https://dependabot.com/docs/config-file/#default_labels
- [x] default_milestone
https://dependabot.com/docs/config-file/#default_milestone
- [ ] allowed_updates
https://dependabot.com/docs/config-file/#allowed_updates
- [ ] ignored_updates
https://dependabot.com/docs/config-file/#automerged_updates
- [ ] version_requirement_updates
https://dependabot.com/docs/config-file/#version_requirement_updates
- [ ] commit_message
https://dependabot.com/docs/config-file/#commit_message